### PR TITLE
Guard against negative active_mode value

### DIFF
--- a/src/geckolib/automation/watercare.py
+++ b/src/geckolib/automation/watercare.py
@@ -88,7 +88,7 @@ class GeckoWaterCare(GeckoAutomationFacadeBase):
         if self.active_mode < 0 or self.active_mode > len(
             GeckoConstants.WATERCARE_MODE_STRING
         ):
-            return f"Unknown Water care mode (index:{self.active_mode}"
+            return f"Unknown Water care mode (index:{self.active_mode})"
         return f"{self.name}: {GeckoConstants.WATERCARE_MODE_STRING[self.active_mode]}"
 
     @property

--- a/src/geckolib/automation/watercare.py
+++ b/src/geckolib/automation/watercare.py
@@ -85,7 +85,9 @@ class GeckoWaterCare(GeckoAutomationFacadeBase):
     def __str__(self):
         if self.active_mode is None:
             return f"{self.name}: Waiting..."
-        if self.active_mode > len(GeckoConstants.WATERCARE_MODE_STRING):
+        if self.active_mode < 0 or self.active_mode > len(
+            GeckoConstants.WATERCARE_MODE_STRING
+        ):
             return f"Unknown Water care mode (index:{self.active_mode}"
         return f"{self.name}: {GeckoConstants.WATERCARE_MODE_STRING[self.active_mode]}"
 


### PR DESCRIPTION
For https://github.com/gazoodle/gecko-home-assistant/issues/53

I got the following exception:
```text
2022-04-15 11:05:50 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
File "/usr/local/lib/python3.9/site-packages/geckolib/automation/async_facade.py", line 90, in _facade_update
self._water_care.change_watercare_mode(
File "/usr/local/lib/python3.9/site-packages/geckolib/automation/watercare.py", line 83, in change_watercare_mode
self._on_change(self, old_mode, self.active_mode)
File "/usr/local/lib/python3.9/site-packages/geckolib/driver/observable.py", line 39, in _on_change
f"{self.__class__.__name__} {sender} changed "
File "/usr/local/lib/python3.9/site-packages/geckolib/automation/watercare.py", line 90, in __str__
return f"{self.name}: {GeckoConstants.WATERCARE_MODE_STRING[self.active_mode]}"
IndexError: list index out of range
```

Since there is a guard against values outside the upper bound of the range, I am guessing this exception is due to a negative value, so I added a guard for this as well.

I believe the reason I got this exception is from putting my spa in a mode where the pump runs 24/7 to test for water leak. On the Aeware3 keypad I pressed and hold the light button for a few seconds until `d 24` is displayed, then press again until `f 1` is displayed, the pump should start and that should be enough to reproduce this issue.