### PR TITLE
[codex] Stop protocol failures from auto-retrying on ping

### DIFF
--- a/src/geckolib/async_spa_manager.py
+++ b/src/geckolib/async_spa_manager.py
@@ -545,7 +545,6 @@ class GeckoAsyncSpaMan(ABC, GeckoAsyncTaskMan):
             if self.spa_state in (
                 GeckoSpaState.ERROR_PING_MISSED,
                 GeckoSpaState.ERROR_RF_FAULT,
-                GeckoSpaState.ERROR_NEEDS_ATTENTION,
             ):
                 await self.async_reset()
 

--- a/tests/test_spaman.py
+++ b/tests/test_spaman.py
@@ -2,9 +2,14 @@
 
 from typing import Any
 from unittest import IsolatedAsyncioTestCase, main
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
-from context import GeckoAsyncSpaDescriptor, GeckoAsyncSpaMan, GeckoSpaEvent
+from context import (
+    GeckoAsyncSpaDescriptor,
+    GeckoAsyncSpaMan,
+    GeckoSpaEvent,
+    GeckoSpaState,
+)
 
 
 class SpaManImpl(GeckoAsyncSpaMan):
@@ -86,6 +91,23 @@ class TestSpaMan(IsolatedAsyncioTestCase):
             ],
         )
         self.assertIsNone(facade)
+
+    async def test_ping_received_does_not_reset_needs_attention(self) -> None:
+        self.spaman.set_spa_state(GeckoSpaState.ERROR_NEEDS_ATTENTION)
+
+        with patch.object(self.spaman, "async_reset", new=AsyncMock()) as async_reset:
+            await self.spaman._handle_event(GeckoSpaEvent.RUNNING_PING_RECEIVED)
+
+        async_reset.assert_not_called()
+        self.assertEqual(self.spaman.spa_state, GeckoSpaState.ERROR_NEEDS_ATTENTION)
+
+    async def test_ping_received_resets_ping_missed(self) -> None:
+        self.spaman.set_spa_state(GeckoSpaState.ERROR_PING_MISSED)
+
+        with patch.object(self.spaman, "async_reset", new=AsyncMock()) as async_reset:
+            await self.spaman._handle_event(GeckoSpaEvent.RUNNING_PING_RECEIVED)
+
+        async_reset.assert_awaited_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #92.

This keeps `ERROR_NEEDS_ATTENTION` as an actionable error state when a setup/protocol failure occurs. A successful ping from the in.touch module no longer triggers `async_reset()` from that state, so repeated full-struct setup failures do not loop indefinitely just because the module is still reachable.

The existing auto-recovery behavior is preserved for transient runtime states where it is appropriate: `ERROR_PING_MISSED` and `ERROR_RF_FAULT` still reset when pings resume.

## Validation

- `env UV_CACHE_DIR=.uv-cache uv run pytest tests/test_spaman.py`
- `env UV_CACHE_DIR=.uv-cache uv run ruff check src/geckolib/async_spa_manager.py tests/test_spaman.py`