### PR TITLE
Fix silent loss of the STATP push subscription (stale data): periodic status resync with in-place re-arm

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,23 @@ it impacts the behaviour of the library, it needs changing. Anyway, it's back to
 this also revealed was that we don't need to do the full structure refresh that we had been doing either
 because that was to mitigate the missing change updates. Anyway, quite a big protocol change.
 
+## Done/Fixed in 1.0.16
+ - Fix silent loss of the in.touch2 push subscription. The module stops sending STATP updates
+   while still answering pings, so clients sit on stale data indefinitely (issue #67). A new
+   resync loop re-reads the live log region every 5 minutes; the read itself re-arms the
+   module's push registry, so the push stream recovers in place without a reconnect
+ - Detect the dropped subscription (`RUNNING_SPA_STALE_SUBSCRIPTION`) and escalate to a
+   reconnect only after two consecutive stale resyncs
+ - New `last_statp_at` and `last_data_at` clocks on the spa, with a "Last Data" sensor and a
+   "Resync" button on the spa manager for client diagnostics
+ - Automatic resets are now scheduled, serialized and rate limited to one per 30 seconds, and
+   a watchdog recovers the manager if it is stuck in a recoverable error state for over 120
+   seconds
+ - The sequence pump now survives locate/connect exceptions instead of dying permanently
+ - Fix RF signal and channel sensors never notifying clients of changes
+ - Fix `_last_ping` being unset before the ping loop starts
+ - Simulator gains `pushsuppress` to reproduce the failure offline
+
 ## Done/Fixed in 1.0.15
  - Bump SpaPackStruct to v40
 

--- a/src/geckolib/_version.py
+++ b/src/geckolib/_version.py
@@ -1,3 +1,3 @@
 """Single module version."""
 
-VERSION = "1.0.15"
+VERSION = "1.0.16"

--- a/src/geckolib/async_spa.py
+++ b/src/geckolib/async_spa.py
@@ -92,7 +92,12 @@ class GeckoAsyncSpa(Observable):
         self.config_number = 0
 
         self.struct: GeckoAsyncStructure = GeckoAsyncStructure(self.async_on_set_value)
+        self._last_ping: float | None = None
         self._last_ping_at: datetime | None = None
+        self._last_statp_at: datetime | None = None
+        self._last_statp_monotonic: float | None = None
+        self._last_data_at: datetime | None = None
+        self._consecutive_stale_resyncs: int = 0
         self._needs_reload: bool = False
 
     @property
@@ -260,6 +265,8 @@ class GeckoAsyncSpa(Observable):
 
             return
 
+        self._last_data_at = datetime.now(tz=UTC)
+
         if not await self._connect_load_pack(plateform_key):
             return
 
@@ -332,6 +339,7 @@ class GeckoAsyncSpa(Observable):
         )
         self._taskman.add_task(self._ping_loop(), "Ping loop", "SPA")
         self._taskman.add_task(self._refresh_loop(), "Refresh loop", "SPA")
+        self._taskman.add_task(self._resync_loop(), "Resync loop", "SPA")
         await config_sleep(
             GeckoConstants.CONNECTION_STEP_PAUSE_IN_SECONDS,
             "Async spa connect - before version ",
@@ -490,6 +498,21 @@ class GeckoAsyncSpa(Observable):
         """The datetime of the last successful ping response or None."""
         return self._last_ping_at
 
+    @property
+    def last_statp_at(self) -> datetime | None:
+        """The datetime of the last STATP partial status update or None."""
+        return self._last_statp_at
+
+    @property
+    def last_data_at(self) -> datetime | None:
+        """
+        The datetime of the last state-bearing data or None.
+
+        Refreshed by STATP partial status updates and by status block
+        (re)reads, so it reflects how fresh our copy of the spa state is.
+        """
+        return self._last_data_at
+
     async def _ping_loop(self) -> None:
         _LOGGER.debug("Ping loop started")
 
@@ -578,18 +601,6 @@ class GeckoAsyncSpa(Observable):
                 if not time_to_doit:
                     continue
 
-                if False:
-                    # Removed because I don't think this is required now that ping
-                    # is back to 2 seconds. Time will tell.
-                    if not await self.struct.get(
-                        self._protocol,
-                        self._get_status_block_handler_func,
-                        5,
-                    ):
-                        await self._event_handler(
-                            GeckoSpaEvent.ERROR_PROTOCOL_RETRY_TIME_EXCEEDED
-                        )
-
                 assert self._protocol is not None  # noqa: S101
                 get_channel_handler = await self._protocol.get(
                     self._get_channel_handler_func
@@ -614,11 +625,120 @@ class GeckoAsyncSpa(Observable):
             _LOGGER.exception("Refresh loop caught exception")
             raise
 
+    async def _resync_loop(self) -> None:
+        """
+        Resync Loop.
+
+        Periodically re-read the live part of the status block as a safety
+        net underneath the STATP push stream. The in.touch2 module can
+        silently drop this client's push subscription while still answering
+        pings, which otherwise leaves stale data in place indefinitely.
+        """
+        try:
+            _LOGGER.debug("Resync loop started")
+            while self.isopen:
+                deadline = (
+                    time.monotonic()
+                    + GeckoConfig.SPA_STATUS_RESYNC_FREQUENCY_IN_SECONDS
+                )
+                # Absolute deadline; config-change wakeups (issued on every
+                # device toggle) must not postpone the safety net
+                while (remaining := deadline - time.monotonic()) > 0:
+                    await config_sleep(remaining, "Async spa resync loop")
+                if not self.is_connected:
+                    continue
+                if self._needs_reload:
+                    continue
+                if not self.is_responding_to_pings:
+                    continue
+                await self.async_resync()
+
+        except asyncio.CancelledError:
+            _LOGGER.debug("Resync loop cancelled")
+            raise
+
+        except Exception:
+            _LOGGER.exception("Resync loop caught exception")
+            raise
+
+    STALE_RESYNCS_BEFORE_RECONNECT = 2
+    """Consecutive stale resyncs required before escalating to a reconnect.
+
+    A status block read re-arms the module's push registry by itself
+    (verified on live hardware 2026-07-27: after a resync pulled changed
+    data during a dead window, the next spa-side change arrived via
+    autonomous STATP with no reconnect), so the first detection needs no
+    action beyond the read that made it. Repeated stale resyncs mean the
+    re-arm is not taking - a genuinely wedged module - and only then is
+    the expensive reconnect justified."""
+
+    async def async_resync(self, *, escalate: bool = True) -> bool:
+        """
+        Re-read the live status block now, returning True on success.
+
+        Changed values propagate to watchers through the normal accessor
+        change notifications; an identical block produces no notifications
+        at all.
+
+        If the block content changed while no STATP push had arrived, the
+        module had silently dropped this client's push subscription; the
+        read itself re-arms it. When escalate is True and this happens on
+        STALE_RESYNCS_BEFORE_RECONNECT consecutive resyncs (the re-arm is
+        not working), RUNNING_SPA_STALE_SUBSCRIPTION is raised so the
+        manager can recover by reconnecting; when escalate is False
+        (diagnostic use) this only logs and counts.
+        """
+        if not self.is_connected:
+            _LOGGER.warning("Cannot resync status block when spa not connected")
+            return False
+        assert self._protocol is not None  # noqa: S101
+        assert self.struct.log_class is not None  # noqa: S101
+
+        log_begin: int = self.struct.log_class.begin
+        log_end: int = self.struct.log_class.end
+        before = self.struct.status_block[log_begin:log_end]
+        statp_before = self._last_statp_monotonic
+
+        if not await self.struct.get(
+            self._protocol,
+            self._get_status_block_handler_func,
+            5,
+        ):
+            _LOGGER.warning("Cannot resync status block, protocol retry time exceeded")
+            await self._event_handler(GeckoSpaEvent.ERROR_PROTOCOL_RETRY_TIME_EXCEEDED)
+            return False
+
+        self._last_data_at = datetime.now(tz=UTC)
+        self._on_change()
+
+        after = self.struct.status_block[log_begin:log_end]
+        if after != before and statp_before == self._last_statp_monotonic:
+            self._consecutive_stale_resyncs += 1
+            _LOGGER.warning(
+                "Status block resync found changed data but no partial status "
+                "update had arrived (consecutive detection %d); the module had "
+                "silently dropped our push subscription - this read re-arms it",
+                self._consecutive_stale_resyncs,
+            )
+            if (
+                escalate
+                and self._consecutive_stale_resyncs
+                >= self.STALE_RESYNCS_BEFORE_RECONNECT
+            ):
+                await self._event_handler(GeckoSpaEvent.RUNNING_SPA_STALE_SUBSCRIPTION)
+        return True
+
     async def _async_on_partial_status_update(
         self,
         handler: GeckoAsyncPartialStatusBlockProtocolHandler,
         _sender: tuple,
     ) -> None:
+        self._last_statp_at = datetime.now(tz=UTC)
+        self._last_statp_monotonic = time.monotonic()
+        self._last_data_at = self._last_statp_at
+        # Push traffic proves the subscription is alive (again)
+        self._consecutive_stale_resyncs = 0
+        self._on_change()
         for change in handler.changes:
             self.struct.replace_status_block_segment(change[0], change[1])
 

--- a/src/geckolib/async_spa_manager.py
+++ b/src/geckolib/async_spa_manager.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Self
 
@@ -14,6 +15,7 @@ from .automation import (
     GeckoAsyncFacade,
     GeckoAutomationBase,
 )
+from .config import GeckoConfig, config_sleep
 from .const import GeckoConstants
 from .spa_events import GeckoSpaEvent
 from .spa_state import GeckoSpaState
@@ -49,6 +51,55 @@ class GeckoAsyncSpaMan(ABC, GeckoAsyncTaskMan):
         async def async_press(self) -> None:
             """Press the button."""
             await self._spaman.async_reset()
+
+    class ResyncButton(GeckoAutomationBase):
+        """Re-read the spa status block in place, without reconnecting."""
+
+        def __init__(self, spaman: GeckoAsyncSpaMan) -> None:
+            """Initialize the resync button class."""
+            super().__init__(spaman.unique_id, "Resync", spaman.spa_name, "RESYNC")
+            self._spaman = spaman
+
+        async def async_press(self) -> None:
+            """Press the button."""
+            await self._spaman.async_resync()
+
+    class LastDataSensor(GeckoAutomationBase):
+        """Sensor with the last time state-bearing data arrived, or None."""
+
+        def __init__(self, spaman: GeckoAsyncSpaMan) -> None:
+            """Initialize the last data sensor."""
+            super().__init__(spaman.unique_id, "Last Data", spaman.spa_name, "LASTDATA")
+            self._spaman: GeckoAsyncSpaMan = spaman
+            assert self._spaman.spa is not None  # noqa: S101
+            self._spaman.spa.watch(self._on_spa_change)
+            self._last_data_at: datetime | None = self._spaman.spa.last_data_at
+
+        @property
+        def state(self) -> datetime | None:
+            """The state of the sensor."""
+            return self._last_data_at
+
+        @property
+        def unit_of_measurement(self) -> None:
+            """The unit of measurement for the sensor, or None."""
+            return None
+
+        @property
+        def device_class(self) -> str:
+            """Device class for the last data sensor."""
+            return "timestamp"
+
+        def _on_spa_change(self, *_args: Any) -> None:
+            assert self._spaman.spa is not None  # noqa: S101
+            if self._last_data_at == self._spaman.spa.last_data_at:
+                return
+            self._last_data_at = self._spaman.spa.last_data_at
+            self._on_change()
+
+        def __repr__(self) -> str:
+            """Get string representation."""
+            return f"{self.name}: {self.state}"
 
     class PingSensor(GeckoAutomationBase):
         """Sensor with the last ping time, or None."""
@@ -144,9 +195,9 @@ class GeckoAsyncSpaMan(ABC, GeckoAsyncTaskMan):
             self.set_signal(spaman.spa.signal)
 
         def set_signal(self, signal: int) -> None:
-            """Set signal nstrength."""
-            self.signal = signal
-            self.signal = min(self.signal, 100)
+            """Set signal strength."""
+            self.signal = min(signal, 100)
+            self._on_change()
 
         @property
         def state(self) -> int:
@@ -179,6 +230,7 @@ class GeckoAsyncSpaMan(ABC, GeckoAsyncTaskMan):
         def set_channel(self, channel: int) -> None:
             """Set the radio channel."""
             self.channel = channel
+            self._on_change()
 
         @property
         def state(self) -> int:
@@ -247,9 +299,13 @@ class GeckoAsyncSpaMan(ABC, GeckoAsyncTaskMan):
 
         self._status_sensor: GeckoAsyncSpaMan.StatusSensor | None = None
         self._reconnect_button: GeckoAsyncSpaMan.ReconnectButton | None = None
+        self._resync_button: GeckoAsyncSpaMan.ResyncButton | None = None
         self._ping_sensor: GeckoAsyncSpaMan.PingSensor | None = None
+        self._last_data_sensor: GeckoAsyncSpaMan.LastDataSensor | None = None
         self._radio_sensor: GeckoAsyncSpaMan.RadioConnectionSensor | None = None
         self._channel_sensor: GeckoAsyncSpaMan.RadioChannelSensor | None = None
+        self._reset_lock = asyncio.Lock()
+        self._last_auto_reset_at: float | None = None
 
     ########################################################################
     #
@@ -261,6 +317,7 @@ class GeckoAsyncSpaMan(ABC, GeckoAsyncTaskMan):
         await GeckoAsyncTaskMan.__aenter__(self)
         await self._handle_event(GeckoSpaEvent.SPA_MAN_ENTER)
         self.add_task(self._sequence_pump(), "Sequence Pump", "SPAMAN")
+        self.add_task(self._error_watchdog(), "Error watchdog", "SPAMAN")
         return self
 
     async def __aexit__(self, *exc_info: object) -> None:
@@ -277,19 +334,67 @@ class GeckoAsyncSpaMan(ABC, GeckoAsyncTaskMan):
     async def async_reset(self) -> None:
         """Reset the spa manager."""
         try:
-            self._spa_descriptors = None
-            self._has_descriptors.clear()
-            if self._facade is not None:
-                await self._facade.disconnect()
-                self._facade = None
-                self._facade_state_known.clear()
-            if self._spa is not None:
-                await self._spa.disconnect()
-                self._spa = None
-            self.set_spa_state(GeckoSpaState.IDLE)
+            async with self._reset_lock:
+                self._spa_descriptors = None
+                self._has_descriptors.clear()
+                if self._facade is not None:
+                    await self._facade.disconnect()
+                    self._facade = None
+                    self._facade_state_known.clear()
+                if self._spa is not None:
+                    await self._spa.disconnect()
+                    self._spa = None
+                self.set_spa_state(GeckoSpaState.IDLE)
         except Exception:
             _LOGGER.exception("Exception during reset")
             raise
+
+    async def async_resync(self) -> bool:
+        """
+        Re-read the spa status block in place, without reconnecting.
+
+        Returns True if the resync read succeeded. This never triggers a
+        reconnect, making it suitable for diagnostics; the periodic resync
+        loop inside the spa handles automatic escalation.
+        """
+        if self._spa is None:
+            _LOGGER.warning("Cannot resync, no spa connected")
+            return False
+        return await self._spa.async_resync(escalate=False)
+
+    AUTO_RESET_MIN_INTERVAL_IN_SECONDS = 30.0
+    """Automatic resets are rate limited to bound reset/fail loops when a
+    reconnect persistently fails (see geckolib issue #92); manual resets
+    via the reconnect button are not limited."""
+
+    def _try_schedule_reset(self, name: str) -> None:
+        """
+        Schedule a reset onto a SPAMAN-key task.
+
+        Resets must not be awaited inside SPA-key tasks (the ping, refresh
+        and resync loops) because reset cancels those tasks, including its
+        own caller. Scheduling here keeps the teardown outside the task
+        being torn down. Requests are rate limited and dropped while a
+        reset task with this name is still running.
+        """
+        now = time.monotonic()
+        if (
+            self._last_auto_reset_at is not None
+            and now - self._last_auto_reset_at < self.AUTO_RESET_MIN_INTERVAL_IN_SECONDS
+        ):
+            _LOGGER.debug(
+                "Skipping reset '%s'; last automatic reset was %.1fs ago",
+                name,
+                now - self._last_auto_reset_at,
+            )
+            return
+        self._last_auto_reset_at = now
+        coro = self.async_reset()
+        try:
+            self.add_task(coro, name, "SPAMAN")
+        except RuntimeError:
+            _LOGGER.debug("Reset task '%s' is already running", name)
+            coro.close()
 
     async def async_locate_spas(
         self, spa_address: str | None = None, spa_identifier: str | None = None
@@ -474,9 +579,19 @@ class GeckoAsyncSpaMan(ABC, GeckoAsyncTaskMan):
         return self._reconnect_button
 
     @property
+    def resync_button(self) -> GeckoAsyncSpaMan.ResyncButton | None:
+        """Get the resync button."""
+        return self._resync_button
+
+    @property
     def ping_sensor(self) -> GeckoAsyncSpaMan.PingSensor | None:
         """Get the ping sensor."""
         return self._ping_sensor
+
+    @property
+    def last_data_sensor(self) -> GeckoAsyncSpaMan.LastDataSensor | None:
+        """Get the last data sensor."""
+        return self._last_data_sensor
 
     def __str__(self) -> str:
         """Get the stringized version."""
@@ -520,10 +635,12 @@ class GeckoAsyncSpaMan(ABC, GeckoAsyncTaskMan):
         elif event == GeckoSpaEvent.CONNECTION_STARTED:
             self.set_spa_state(GeckoSpaState.CONNECTING)
             self._reconnect_button = GeckoAsyncSpaMan.ReconnectButton(self)
+            self._resync_button = GeckoAsyncSpaMan.ResyncButton(self)
             await self._handle_event(GeckoSpaEvent.CLIENT_HAS_RECONNECT_BUTTON)
 
         elif event == GeckoSpaEvent.CONNECTION_GOT_CHANNEL:
             self._ping_sensor = GeckoAsyncSpaMan.PingSensor(self)
+            self._last_data_sensor = GeckoAsyncSpaMan.LastDataSensor(self)
             self._radio_sensor = GeckoAsyncSpaMan.RadioConnectionSensor(self)
             self._channel_sensor = GeckoAsyncSpaMan.RadioChannelSensor(self)
             await self._handle_event(GeckoSpaEvent.CLIENT_HAS_PING_SENSOR)
@@ -547,10 +664,16 @@ class GeckoAsyncSpaMan(ABC, GeckoAsyncTaskMan):
                 GeckoSpaState.ERROR_RF_FAULT,
                 GeckoSpaState.ERROR_NEEDS_ATTENTION,
             ):
-                await self.async_reset()
+                self._try_schedule_reset("Ping recovery reset")
 
         elif event == GeckoSpaEvent.RUNNING_SPA_NEEDS_RELOAD:
-            await self.async_reset()
+            self._try_schedule_reset("Reload reset")
+
+        elif event == GeckoSpaEvent.RUNNING_SPA_STALE_SUBSCRIPTION:
+            _LOGGER.warning(
+                "Push subscription lost while pings still succeed; reconnecting"
+            )
+            self._try_schedule_reset("Stale subscription reset")
 
         elif event == GeckoSpaEvent.ERROR_RF_ERROR:
             if self.spa_state == GeckoSpaState.CONNECTED:
@@ -614,38 +737,97 @@ class GeckoAsyncSpaMan(ABC, GeckoAsyncTaskMan):
                 await self._state_change.wait()
                 self._state_change.clear()
 
-                if (
-                    self.spa_state == GeckoSpaState.IDLE
-                    and self._spa_descriptors is None
-                ):
-                    _LOGGER.debug("Sequence pump did locate")
-                    await self.async_locate_spas(self._spa_address)
+                try:
+                    if (
+                        self.spa_state == GeckoSpaState.IDLE
+                        and self._spa_descriptors is None
+                    ):
+                        _LOGGER.debug("Sequence pump did locate")
+                        await self.async_locate_spas(self._spa_address)
 
-                if (
-                    self.spa_state == GeckoSpaState.LOCATED_SPAS
-                    and self._spa_identifier is not None
-                    and self._facade is None
-                ):
-                    _LOGGER.debug("Sequence pump did connect")
-                    if self._spa_descriptors is not None:
-                        await self.async_connect_to_spa(
-                            next(
-                                (
-                                    d
-                                    for d in self._spa_descriptors
-                                    if d.identifier_as_string == self._spa_identifier
-                                ),
-                                None,
+                    if (
+                        self.spa_state == GeckoSpaState.LOCATED_SPAS
+                        and self._spa_identifier is not None
+                        and self._facade is None
+                    ):
+                        _LOGGER.debug("Sequence pump did connect")
+                        if self._spa_descriptors is not None:
+                            await self.async_connect_to_spa(
+                                next(
+                                    (
+                                        d
+                                        for d in self._spa_descriptors
+                                        if d.identifier_as_string
+                                        == self._spa_identifier
+                                    ),
+                                    None,
+                                )
                             )
-                        )
-                    else:
-                        await self.async_connect(
-                            self._spa_identifier, self._spa_address
-                        )
+                        else:
+                            await self.async_connect(
+                                self._spa_identifier, self._spa_address
+                            )
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    # The pump must survive locate/connect failures or both
+                    # automatic recovery and the reconnect button die with
+                    # it; the error watchdog will retry later.
+                    _LOGGER.exception(
+                        "Sequence pump caught exception, will keep running"
+                    )
 
         except asyncio.CancelledError:
             _LOGGER.debug("Spaman sequence pump cancelled")
             raise
+
+    async def _error_watchdog(self) -> None:
+        """
+        Error watchdog loop.
+
+        Recovery normally rides on the ping loop (a successful ping while
+        in an error state schedules a reset), but the ping loop dies with
+        the spa object. If a reset fails to reconnect there is no ping
+        loop any more and the manager would otherwise park in an error
+        state forever. This loop is the backstop: if the manager has been
+        in any recoverable error state for longer than the retry window it
+        forces a reset.
+        """
+        error_states = (
+            GeckoSpaState.ERROR_SPA_NOT_FOUND,
+            GeckoSpaState.ERROR_NEEDS_ATTENTION,
+            GeckoSpaState.ERROR_PING_MISSED,
+            GeckoSpaState.ERROR_RF_FAULT,
+        )
+        watchdog_max_poll_seconds = 30.0
+        error_since: float | None = None
+        try:
+            _LOGGER.debug("Error watchdog started")
+            while True:
+                retry_after = GeckoConfig.SPA_RECONNECT_RETRY_FREQUENCY_IN_SECONDS
+                await config_sleep(
+                    min(watchdog_max_poll_seconds, retry_after / 4.0),
+                    "Error watchdog",
+                )
+                if self.spa_state not in error_states:
+                    error_since = None
+                    continue
+                if error_since is None:
+                    error_since = time.monotonic()
+                    continue
+                if time.monotonic() - error_since >= retry_after:
+                    _LOGGER.warning(
+                        "Spa stuck in state '%s' for over %s seconds, "
+                        "attempting automatic recovery",
+                        GeckoSpaState.to_string(self.spa_state),
+                        retry_after,
+                    )
+                    error_since = None
+                    await self.async_reset()
+
+        except asyncio.CancelledError:
+            _LOGGER.debug("Error watchdog cancelled")
+            raise
         except Exception:
-            _LOGGER.exception("Sequence pump caught exception")
+            _LOGGER.exception("Error watchdog caught exception")
             raise

--- a/src/geckolib/config.py
+++ b/src/geckolib/config.py
@@ -32,6 +32,14 @@ class _GeckoConfig:
     SPA_PACK_REFRESH_FREQUENCY_IN_SECONDS = 1
     """Frequency in seconds to request all LOG data from spa"""
 
+    SPA_STATUS_RESYNC_FREQUENCY_IN_SECONDS = 1
+    """Frequency in seconds to re-read the live status block as a safety
+    net underneath the STATP push stream"""
+
+    SPA_RECONNECT_RETRY_FREQUENCY_IN_SECONDS = 1
+    """Time in seconds the manager may remain in an error state before the
+    error watchdog attempts automatic recovery"""
+
     PROTOCOL_TIMEOUT_IN_SECONDS = 1
     """Default timeout for most protocol commands"""
 
@@ -57,6 +65,8 @@ class _GeckoActiveConfig(_GeckoConfig):
     PING_DEVICE_NOT_RESPONDING_TIMEOUT_IN_SECONDS = 10
     FACADE_UPDATE_FREQUENCY_IN_SECONDS = 28800
     SPA_PACK_REFRESH_FREQUENCY_IN_SECONDS = 28800
+    SPA_STATUS_RESYNC_FREQUENCY_IN_SECONDS = 300
+    SPA_RECONNECT_RETRY_FREQUENCY_IN_SECONDS = 120
     PROTOCOL_TIMEOUT_IN_SECONDS = 4
     PAUSE_BETWEEN_RETRIES_IN_SECONDS = 0.4
 
@@ -72,6 +82,8 @@ class _GeckoIdleConfig(_GeckoConfig):
     PING_DEVICE_NOT_RESPONDING_TIMEOUT_IN_SECONDS = 120
     FACADE_UPDATE_FREQUENCY_IN_SECONDS = 3600
     SPA_PACK_REFRESH_FREQUENCY_IN_SECONDS = 3600
+    SPA_STATUS_RESYNC_FREQUENCY_IN_SECONDS = 300
+    SPA_RECONNECT_RETRY_FREQUENCY_IN_SECONDS = 120
     PROTOCOL_TIMEOUT_IN_SECONDS = 4
     PAUSE_BETWEEN_RETRIES_IN_SECONDS = 0.4
 

--- a/src/geckolib/spa_events.py
+++ b/src/geckolib/spa_events.py
@@ -85,6 +85,10 @@ class GeckoSpaEvent(Enum):
     """A running spa will update the spapack data and radio strength periodically"""
     RUNNING_SPA_NEEDS_RELOAD = 306
     """A running spa has detected that it needs a complete reload"""
+    RUNNING_SPA_STALE_SUBSCRIPTION = 310
+    """A status block re-sync found changed data although no partial status
+    update (STATP) had arrived, meaning the in.touch2 module has silently
+    dropped this client's push subscription while still answering pings"""
 
     # Events targeted at clients, to determine when things can be shown
     # or hidden in the UI

--- a/src/geckolib/utils/simulator.py
+++ b/src/geckolib/utils/simulator.py
@@ -227,6 +227,29 @@ class GeckoSimulator(GeckoCmd, GeckoAsyncTaskMan):
         self._do_rferr = args.lower() == "true"
         print(f"RFERR mode set to {self._do_rferr}")
 
+    def do_pushsuppress(self, args: str) -> None:
+        """
+        Suppress or restore async STATP push notifications.
+
+        Simulates the in.touch2 module silently dropping this client's
+        push subscription while continuing to answer pings, which is the
+        failure mode where clients show stale data while apparently
+        connected.
+
+        usage: pushsuppress [ON|OFF] where no parameter shows the
+               current state
+        """
+        arg = args.strip().upper()
+        if arg == "ON":
+            self._send_structure_change = False
+            print("STATP push suppressed (pings still answered)")
+        elif arg == "OFF":
+            self._send_structure_change = True
+            print("STATP push restored")
+        else:
+            state = "suppressed" if not self._send_structure_change else "active"
+            print(f"STATP push is currently {state}")
+
     def complete_parse(
         self, text: str, _line: str, _start_idx: int, _end_idx: int
     ) -> list[str]:

--- a/tests/test_resync.py
+++ b/tests/test_resync.py
@@ -1,0 +1,320 @@
+"""Unit tests for the status block resync safety net."""  # noqa: INP001
+
+import asyncio
+import contextlib
+import time
+from typing import Any, ClassVar
+from unittest import IsolatedAsyncioTestCase, main
+
+from context import (
+    GeckoAsyncSpa,
+    GeckoAsyncSpaDescriptor,
+    GeckoAsyncSpaMan,
+    GeckoConfig,
+    GeckoSpaEvent,
+    GeckoSpaState,
+)
+
+from geckolib import config as gecko_config
+
+STATP_DATA = b"\x09\x09"
+
+
+class FakeLogClass:
+    """Just enough of a GeckoLogStruct for resync range computation."""
+
+    begin = 0
+    end = 4
+
+
+class FakeStatpHandler:
+    """Just enough of a partial status block handler for the spa callback."""
+
+    changes: ClassVar[list[tuple[int, bytes]]] = [(2, STATP_DATA)]
+
+
+class SpaHarness:
+    """Host a GeckoAsyncSpa wired for resync testing without a network."""
+
+    def __init__(self) -> None:
+        """Initialize the harness with a connected-looking spa."""
+        self.events: list[GeckoSpaEvent] = []
+        descriptor = GeckoAsyncSpaDescriptor(b"TestID", "Test Name", (1, 2))
+        self.spa = GeckoAsyncSpa(b"CLIENT", descriptor, None, self._on_event)
+        self.spa._is_connected = True
+        self.spa._protocol = object()
+        self.spa.struct.log_class = FakeLogClass()
+        self.change_notifications = 0
+        self.spa.watch(self._on_spa_change)
+
+    async def _on_event(self, event: GeckoSpaEvent, **_kwargs: Any) -> None:
+        self.events.append(event)
+
+    def _on_spa_change(self, *_args: Any) -> None:
+        self.change_notifications += 1
+
+    def install_fake_get(
+        self,
+        *,
+        result: bool = True,
+        mutate: bool = False,
+        statp_during: bool = False,
+    ) -> None:
+        """
+        Replace struct.get with a fake, optionally mutating the block.
+
+        When mutate is True every call writes fresh bytes, so each resync
+        sees drift (as if the spa changed state between reads).
+        """
+        call_count = [0]
+
+        async def fake_get(
+            _protocol: Any, _create_func: Any, _packet_timeout: Any = None
+        ) -> bool:
+            call_count[0] += 1
+            if statp_during:
+                self.spa._last_statp_monotonic = time.monotonic()
+            if mutate:
+                fresh = bytes([call_count[0], call_count[0] + 1])
+                self.spa.struct.replace_status_block_segment(0, fresh)
+            return result
+
+        self.spa.struct.get = fake_get
+
+
+class TestPartialStatusUpdate(IsolatedAsyncioTestCase):
+    """The STATP receipt hook must stamp both data clocks."""
+
+    async def test_statp_stamps_clocks_and_applies_changes(self) -> None:
+        harness = SpaHarness()
+        self.assertIsNone(harness.spa.last_statp_at)
+        self.assertIsNone(harness.spa.last_data_at)
+
+        await harness.spa._async_on_partial_status_update(FakeStatpHandler(), (1, 2))
+
+        self.assertIsNotNone(harness.spa.last_statp_at)
+        self.assertEqual(harness.spa.last_data_at, harness.spa.last_statp_at)
+        self.assertIsNotNone(harness.spa._last_statp_monotonic)
+        self.assertEqual(harness.spa.struct.status_block[2:4], STATP_DATA)
+        self.assertGreater(harness.change_notifications, 0)
+
+
+class TestAsyncResync(IsolatedAsyncioTestCase):
+    """Behavior of the in-place status block resync."""
+
+    async def test_success_without_drift_is_silent(self) -> None:
+        harness = SpaHarness()
+        harness.install_fake_get(result=True)
+
+        self.assertTrue(await harness.spa.async_resync())
+
+        self.assertListEqual(harness.events, [])
+        self.assertIsNotNone(harness.spa.last_data_at)
+        self.assertIsNone(harness.spa.last_statp_at)
+
+    async def test_first_stale_resync_rearms_without_escalating(self) -> None:
+        harness = SpaHarness()
+        harness.install_fake_get(result=True, mutate=True)
+
+        self.assertTrue(await harness.spa.async_resync())
+
+        # The read itself re-arms the subscription; no reconnect on strike one
+        self.assertListEqual(harness.events, [])
+        self.assertEqual(harness.spa._consecutive_stale_resyncs, 1)
+
+    async def test_second_consecutive_stale_resync_escalates(self) -> None:
+        harness = SpaHarness()
+        harness.install_fake_get(result=True, mutate=True)
+
+        self.assertTrue(await harness.spa.async_resync())
+        self.assertTrue(await harness.spa.async_resync())
+
+        self.assertListEqual(
+            harness.events, [GeckoSpaEvent.RUNNING_SPA_STALE_SUBSCRIPTION]
+        )
+
+    async def test_statp_between_stale_resyncs_resets_counter(self) -> None:
+        harness = SpaHarness()
+        harness.install_fake_get(result=True, mutate=True)
+
+        self.assertTrue(await harness.spa.async_resync())
+        # Push traffic resumes - the re-arm worked
+        await harness.spa._async_on_partial_status_update(FakeStatpHandler(), (1, 2))
+        self.assertEqual(harness.spa._consecutive_stale_resyncs, 0)
+        # A later stale resync is strike one again, not strike two
+        self.assertTrue(await harness.spa.async_resync())
+
+        self.assertListEqual(harness.events, [])
+
+    async def test_drift_with_concurrent_statp_does_not_escalate(self) -> None:
+        harness = SpaHarness()
+        harness.install_fake_get(result=True, mutate=True, statp_during=True)
+
+        self.assertTrue(await harness.spa.async_resync())
+        self.assertTrue(await harness.spa.async_resync())
+
+        self.assertListEqual(harness.events, [])
+        self.assertEqual(harness.spa._consecutive_stale_resyncs, 0)
+
+    async def test_drift_with_escalation_disabled_is_silent(self) -> None:
+        harness = SpaHarness()
+        harness.install_fake_get(result=True, mutate=True)
+
+        self.assertTrue(await harness.spa.async_resync(escalate=False))
+        self.assertTrue(await harness.spa.async_resync(escalate=False))
+        self.assertTrue(await harness.spa.async_resync(escalate=False))
+
+        self.assertListEqual(harness.events, [])
+
+    async def test_failure_fires_retry_time_exceeded(self) -> None:
+        harness = SpaHarness()
+        harness.install_fake_get(result=False)
+
+        self.assertFalse(await harness.spa.async_resync())
+
+        self.assertListEqual(
+            harness.events, [GeckoSpaEvent.ERROR_PROTOCOL_RETRY_TIME_EXCEEDED]
+        )
+        self.assertIsNone(harness.spa.last_data_at)
+
+    async def test_not_connected_returns_false(self) -> None:
+        harness = SpaHarness()
+        harness.spa._is_connected = False
+        harness.install_fake_get(result=True)
+
+        self.assertFalse(await harness.spa.async_resync())
+
+        self.assertListEqual(harness.events, [])
+
+
+class SpaManImpl(GeckoAsyncSpaMan):
+    """Spa manager to test with."""
+
+    def __init__(self) -> None:
+        """Initialize the spaman class."""
+        super().__init__("CLIENT_UUID", spa_identifier="TestID", spa_name="Test Name")
+        self.events: list[GeckoSpaEvent] = []
+
+    async def handle_event(self, event: GeckoSpaEvent, **_kwargs: object) -> None:
+        self.events.append(event)
+
+
+class TestErrorWatchdog(IsolatedAsyncioTestCase):
+    """The error watchdog must recover states the ping loop cannot."""
+
+    def setUp(self) -> None:
+        self._saved_retry = GeckoConfig.SPA_RECONNECT_RETRY_FREQUENCY_IN_SECONDS
+        GeckoConfig.SPA_RECONNECT_RETRY_FREQUENCY_IN_SECONDS = 0.05
+        # The module-global event binds to the first loop that waits on it;
+        # IsolatedAsyncioTestCase runs every test in a fresh loop
+        gecko_config.ConfigChangeEvent = asyncio.Event()
+
+    def tearDown(self) -> None:
+        GeckoConfig.SPA_RECONNECT_RETRY_FREQUENCY_IN_SECONDS = self._saved_retry
+
+    async def test_watchdog_recovers_stuck_error_state(self) -> None:
+        spaman = SpaManImpl()
+        reset_done = asyncio.Event()
+
+        async def fake_reset() -> None:
+            reset_done.set()
+
+        spaman.async_reset = fake_reset
+        spaman.set_spa_state(GeckoSpaState.ERROR_NEEDS_ATTENTION)
+
+        task = asyncio.create_task(spaman._error_watchdog())
+        try:
+            await asyncio.wait_for(reset_done.wait(), timeout=5)
+        finally:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+    async def test_watchdog_leaves_healthy_state_alone(self) -> None:
+        spaman = SpaManImpl()
+        resets: list[int] = []
+
+        async def fake_reset() -> None:
+            resets.append(1)
+
+        spaman.async_reset = fake_reset
+        self.assertEqual(spaman.spa_state, GeckoSpaState.IDLE)
+
+        task = asyncio.create_task(spaman._error_watchdog())
+        await asyncio.sleep(0.2)
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+        self.assertListEqual(resets, [])
+
+
+class TestScheduledReset(IsolatedAsyncioTestCase):
+    """Reset scheduling must serialize and never run inside SPA tasks."""
+
+    async def test_schedule_reset_runs_and_dedups(self) -> None:
+        spaman = SpaManImpl()
+        started = asyncio.Event()
+        release = asyncio.Event()
+        calls: list[int] = []
+
+        async def fake_reset() -> None:
+            calls.append(1)
+            started.set()
+            await release.wait()
+
+        spaman.async_reset = fake_reset
+
+        spaman._try_schedule_reset("Test reset")
+        await asyncio.wait_for(started.wait(), timeout=2)
+        # Second request while the first is still running is dropped
+        spaman._try_schedule_reset("Test reset")
+        release.set()
+        await asyncio.sleep(0)
+
+        self.assertListEqual(calls, [1])
+        await spaman.gather()
+
+    async def test_auto_resets_are_rate_limited(self) -> None:
+        spaman = SpaManImpl()
+        calls: list[int] = []
+
+        async def fake_reset() -> None:
+            calls.append(1)
+
+        spaman.async_reset = fake_reset
+
+        spaman._try_schedule_reset("Test reset")
+        await asyncio.sleep(0.05)
+        # Within the rate-limit window: dropped
+        spaman._try_schedule_reset("Test reset")
+        await asyncio.sleep(0.05)
+        self.assertListEqual(calls, [1])
+
+        # Outside the window: runs again
+        spaman._last_auto_reset_at = (
+            time.monotonic() - spaman.AUTO_RESET_MIN_INTERVAL_IN_SECONDS - 1
+        )
+        spaman._try_schedule_reset("Test reset")
+        await asyncio.sleep(0.05)
+        self.assertListEqual(calls, [1, 1])
+        await spaman.gather()
+
+    async def test_stale_subscription_event_schedules_reset(self) -> None:
+        spaman = SpaManImpl()
+        reset_done = asyncio.Event()
+
+        async def fake_reset() -> None:
+            reset_done.set()
+
+        spaman.async_reset = fake_reset
+
+        await spaman._handle_event(GeckoSpaEvent.RUNNING_SPA_STALE_SUBSCRIPTION)
+        await asyncio.wait_for(reset_done.wait(), timeout=2)
+
+        self.assertIn(GeckoSpaEvent.RUNNING_SPA_STALE_SUBSCRIPTION, spaman.events)
+        await spaman.gather()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Problem

The in.touch2 module silently drops a client's STATP push subscription while continuing to answer APING. From the client's side nothing looks wrong: pings succeed, state stays "Connected", but no further state updates ever arrive. On my hardware (inYT 654 v2.0, cfg 82/log 81) this happens roughly every 75 minutes, around the clock. Because the protocol has no subscribe verb (the module keeps a private push-client table, and APING is answered by a separate firmware subsystem), the drop is structurally invisible to the client.

This is the root cause of #67 (temperature frozen until the user toggles something) and of the stale-entity reports on the HA integration (gecko-home-assistant #192, #182). Users there have independently built watchdog automations and smart-plug power cycles to work around it.

### History

The library used to mask this with a periodic status-block re-read (30s/120s), removed in f03c039 ("Removed because I don't think this is required now that ping is back to 2 seconds. Time will tell"). #67 was filed 26 days later. The field data says the 2s ping is not sufficient: pings keep succeeding while the push registry forgets the client.

### Fix

- **Dedicated resync loop**: re-read the live log region every 5 minutes (`SPA_STATUS_RESYNC_FREQUENCY_IN_SECONDS`, same active/idle) on an absolute deadline, so config-change wakeups cannot starve it. Accessor notifications are diff-gated, so a no-change resync is completely silent.
- **In-place re-arm (key discovery, verified live)**: the STATU read itself re-registers the client in the module's push table. Verified on hardware: with a dead subscription, a bare resync pulled the missed state AND the next spa-side change arrived via autonomous STATP, with no reconnect needed.
- **Detection and bounded escalation**: if a resync finds changed data although no STATP arrived, the subscription had been dropped (`RUNNING_SPA_STALE_SUBSCRIPTION`, id 310 chosen clear of PR #87's 307). Escalation to a reconnect happens only after two consecutive stale resyncs (re-arm failing repeatedly means a genuinely wedged module); any received STATP resets the counter.
- **Recovery hardening**: automatic resets are scheduled onto SPAMAN tasks (never awaited inside the SPA tasks they cancel), serialized behind a lock, and rate-limited to one per 30s. That also bounds the reset loop in #92 without making ERROR_NEEDS_ATTENTION sticky (cf. PR #93). A new error watchdog forces recovery when the manager is stuck in any recoverable error state for over 120s, covering the dead-ping-loop and spa-is-None dead-ends where neither auto-recovery nor the reconnect button work. The sequence pump now survives locate/connect exceptions (#64 family).
- **Diagnostics**: `last_statp_at` / `last_data_at` on GeckoAsyncSpa; "Last Data" timestamp sensor and a "Resync" button (in-place re-read, never reconnects) on GeckoAsyncSpaMan.
- **Fixes**: RF signal/channel sensors never fired change notifications; `_last_ping` unset before the ping loop starts.
- **Test/repro**: simulator gains `pushsuppress` (answers pings, drops STATP, reproducing the failure offline); `tests/test_resync.py` covers the resync, detection, re-arm counting, watchdog and rate-limit behavior. 128 tests, ruff clean.

### Field results

6-day soak on my spa: 113 subscription drops detected and healed, zero user-visible staleness, external watchdog (3h threshold) never fired. With the re-arm change, heals involve no reconnect and no client-visible churn.

### Notes

I included the README changelog entry and the version bump to 1.0.16 so the companion integration PR has something to pin against; happy to drop both if you would rather handle releases yourself. The whole change is one commit, so it is easy to rebase or split if you want it broken up.

Fixes #67. Materially improves #92, #91, #64.
